### PR TITLE
Add an adapter shield for D1 Mini shields.

### DIFF
--- a/shields/d1mini/d1mini-openmv.fz
+++ b/shields/d1mini/d1mini-openmv.fz
@@ -1,0 +1,6516 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module fritzingVersion="0.9.3b.04.19.5c895d327c44a3114e5fcc9d8260daf0cbb52806" icon=".png">
+    <boards>
+        <board moduleId="TwoLayerRectanglePCBModuleID" title="Rectangular PCB - Resizable" instance="PCB1" width="3.56cm" height="2.04cm"/>
+    </boards>
+    <views>
+        <view name="breadboardView" backgroundColor="#ffffff" gridSize="0.1in" showGrid="1" alignToGrid="1" viewFromBelow="0"/>
+        <view name="schematicView" backgroundColor="#ffffff" gridSize="0.05in" showGrid="1" alignToGrid="1" viewFromBelow="0"/>
+        <view name="pcbView" backgroundColor="#333333" gridSize="0.025in" showGrid="1" alignToGrid="1" viewFromBelow="0" autorouteViaHoleSize="0.4mm" autorouteViaRingThickness="0.3mm" autorouteTraceWidth="24" GPG_Keepout="" DRC_Keepout="0.01in"/>
+    </views>
+    <instances>
+        <instance moduleIdRef="TwoLayerRectanglePCBModuleID" modelIndex="5736" path=":/resources/parts/core/rectangle_pcb_two_layers.fzp">
+            <property name="layers" value="2"/>
+            <property name="width" value="35.600000000000001"/>
+            <property name="height" value="20.399999999999999"/>
+            <title>PCB1</title>
+            <views>
+                <breadboardView layer="">
+                    <geometry z="0.50103" x="0" y="0"/>
+                </breadboardView>
+                <pcbView layer="board" locked="true">
+                    <geometry z="1.50106" x="0.052118" y="-1.42109e-14"/>
+                </pcbView>
+                <schematicView layer="icon">
+                    <geometry z="0.50103" x="0" y="0"/>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="generic_female_alternating_pin_header_8_100mil_hs_0.9mm_0.4mm" modelIndex="86009413" path="/home/sheep/.config/Fritzing/partfactory/bbf9f808e12917fe4cff3a2a03d46965/core/generic_female_alternating_pin_header_8_100mil_hs_0.9mm_0.4mm.fzp">
+            <property name="hole size" value="0.9mm,0.4mm"/>
+            <property name="form" value="♀ (female)"/>
+            <title>3V A0 D4 D3 CS SCK SO SI</title>
+            <views>
+                <breadboardView layer="breadboard">
+                    <geometry z="2.50102" x="211.503" y="76.5015"/>
+                    <connectors>
+                        <connector connectorId="connector4" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031962" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032498" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector2" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009807" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032536" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector7" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009672" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032453" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector1" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009830" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032593" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector3" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009793" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032517" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009837" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032580" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector6" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009765" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032504" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector5" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031955" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032494" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0" locked="true">
+                    <geometry z="5.50105" x="-1.8" y="-1.8"/>
+                    <titleGeometry visible="true" x="-19.3164" y="35.0057" z="13.0039" xOffset="-17.5164" yOffset="36.8057" textColor="#000000" fontSize="3">
+                        <transform m11="0" m12="-1" m13="0" m21="1" m22="0" m23="0" m31="30" m32="34" m33="1"/>
+                        <displayKey key=""/>
+                    </titleGeometry>
+                    <connectors>
+                        <connector connectorId="connector7" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009672" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector6" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009765" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematic">
+                    <geometry z="2.50102" x="-35.9737" y="-139.49">
+                        <transform m11="-1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="18" m32="0" m33="1"/>
+                    </geometry>
+                    <titleGeometry visible="true" x="-88.5107" y="-64.8905" z="7.00396" xOffset="-52.5369" yOffset="74.5995" textColor="#000000" fontSize="5">
+                        <displayKey key=""/>
+                        <displayKey key="part number"/>
+                    </titleGeometry>
+                    <connectors>
+                        <connector connectorId="connector4" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031962" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032498" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector2" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009807" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032536" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector7" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009672" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032453" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector1" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009830" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032593" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector3" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009793" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032517" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009837" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032580" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector6" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009765" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032504" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector5" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031955" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032494" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="generic_female_alternating_pin_header_8_100mil_hs_0.9mm_0.4mm" modelIndex="86009422" path="/home/sheep/.config/Fritzing/partfactory/bbf9f808e12917fe4cff3a2a03d46965/core/generic_female_alternating_pin_header_8_100mil_hs_0.9mm_0.4mm.fzp">
+            <property name="hole size" value="0.9mm,0.4mm"/>
+            <property name="form" value="♀ (female)"/>
+            <title>G  5V SCL SDA D0 -- -- RST</title>
+            <views>
+                <breadboardView layer="breadboard">
+                    <geometry z="2.50101" x="211.291" y="-23.7006"/>
+                    <connectors>
+                        <connector connectorId="connector4" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009702" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032549" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector7" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009653" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032489" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector3" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031853" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032441" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009535" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032437" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector6" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009618" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032466" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector5" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009693" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032567" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0" locked="true">
+                    <geometry z="5.50104" x="115.2" y="-1.8"/>
+                    <titleGeometry visible="true" x="82.8669" y="35.4889" z="13.004" xOffset="-32.3331" yOffset="37.2889" textColor="#000000" fontSize="3">
+                        <transform m11="0" m12="-1" m13="0" m21="1" m22="0" m23="0" m31="30" m32="34" m33="1"/>
+                        <displayKey key=""/>
+                    </titleGeometry>
+                    <connectors>
+                        <connector connectorId="connector7" layer="copper0" groundFillSeed="true">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009653" layer="copper0trace"/>
+                                <connect connectorId="connector1" modelIndex="86032489" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector3" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031853" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector5" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009693" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematic">
+                    <geometry z="2.50101" x="143.974" y="-139.51"/>
+                    <titleGeometry visible="true" x="143.128" y="-65.2763" z="7.004" xOffset="-0.846227" yOffset="74.2337" textColor="#000000" fontSize="5">
+                        <displayKey key=""/>
+                        <displayKey key="part number"/>
+                    </titleGeometry>
+                    <connectors>
+                        <connector connectorId="connector4" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009702" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032549" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector7" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009653" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032489" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector3" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031853" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032441" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009535" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032437" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector6" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009618" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032466" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector5" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009693" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032567" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009535" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7036</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.5004" x="119.016" y="4.67046" x1="0" y1="0" x2="-13.5282" y2="0.16105" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50047" x="121.95" y="4.5" x1="0" y1="0" x2="-18.9" y2="1.68754e-14" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031886" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009422" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.5004" x="119.016" y="4.67046" x1="0" y1="0" x2="-13.5282" y2="0.16105" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009618" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7071</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50041" x="119.66" y="58.1392" x1="0" y1="0" x2="-97.1134" y2="9.98513" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009625" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50046" x="121.95" y="58.5" x1="0" y1="0" x2="-5.027" y2="4.4707" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009625" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009422" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50041" x="119.66" y="58.1392" x1="0" y1="0" x2="-97.1134" y2="9.98513" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009625" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009625" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7074</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50042" x="116.923" y="62.9707" x1="0" y1="0" x2="-94.8726" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009632" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009618" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50045" x="116.923" y="62.9707" x1="0" y1="0" x2="-17.8766" y2="0" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009632" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009618" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50042" x="116.923" y="62.9707" x1="0" y1="0" x2="-94.8726" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009632" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009618" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009632" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7077</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50043" x="27.0565" y="62.9707" x1="0" y1="0" x2="-5.00647" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031920" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009625" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50044" x="99.046" y="62.9707" x1="0" y1="0" x2="-4.50941" y2="4.50941" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031920" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009625" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50043" x="27.0565" y="62.9707" x1="0" y1="0" x2="-5.00647" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031920" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009625" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009639" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7080</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50044" x="5.95887" y="57.3339" x1="0" y1="0" x2="96.1471" y2="9.82408" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009646" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50043" x="22.05" y="58.5" x1="0" y1="0" x2="7.26117" y2="-0.0387011" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009646" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031860" layer="copper0"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50044" x="5.95887" y="57.3339" x1="0" y1="0" x2="96.1471" y2="9.82408" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009646" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009646" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7083</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50045" x="9.01882" y="62.9707" x1="0" y1="0" x2="94.0312" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009851" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009639" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50049" x="29.3112" y="58.4613" x1="0" y1="0" x2="4.50941" y2="4.50941" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009851" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009639" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50045" x="9.01882" y="62.9707" x1="0" y1="0" x2="94.0312" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009851" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009639" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009653" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7086</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50046" x="99.046" y="62.9707" x1="0" y1="0" x2="4.004" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009851" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.5005" x="116.923" y="62.9707" x1="0" y1="0" x2="4.1274" y2="4.5293" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009422" layer="copper0"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009851" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50046" x="99.046" y="62.9707" x1="0" y1="0" x2="4.004" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009851" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009672" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7093</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50047" x="5.63676" y="68.6075" x1="0" y1="0" x2="95.5029" y2="-1.44945" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009679" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50054" x="4.05" y="67.5" x1="0" y1="0" x2="4.96882" y2="-4.5293" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009679" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009413" layer="copper0"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50047" x="5.63676" y="68.6075" x1="0" y1="0" x2="95.5029" y2="-1.44945" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009679" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009679" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7096</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50048" x="9.01882" y="62.9707" x1="0" y1="0" x2="94.0312" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009844" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009672" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50053" x="9.01882" y="62.9707" x1="0" y1="0" x2="18.0376" y2="0" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009844" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009672" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50048" x="9.01882" y="62.9707" x1="0" y1="0" x2="94.0312" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009844" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009672" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009686" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7099</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50049" x="99.046" y="62.9707" x1="0" y1="0" x2="4.004" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009844" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50051" x="31.5659" y="67.4801" x1="0" y1="0" x2="72.3841" y2="0.01989" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031886" layer="copper0"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009844" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50049" x="99.046" y="62.9707" x1="0" y1="0" x2="4.004" y2="4.52929" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009844" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009693" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7102</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.5005" x="119.66" y="47.3488" x1="0" y1="0" x2="-97.1134" y2="-25.446" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009709" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50076" x="121.05" y="49.5" x1="0" y1="0" x2="-8.47576" y2="-9.07635" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009709" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009422" layer="copper0"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.5005" x="119.66" y="47.3488" x1="0" y1="0" x2="-97.1134" y2="-25.446" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009709" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009702" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7105</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50051" x="120.627" y="39.2963" x1="0" y1="0" x2="-98.0797" y2="-8.05252" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009730" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50069" x="121.95" y="40.5" x1="0" y1="0" x2="-13.885" y2="13.4519" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009730" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009422" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50051" x="120.627" y="39.2963" x1="0" y1="0" x2="-98.0797" y2="-8.05252" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009730" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009709" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7108</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50052" x="116.923" y="53.9519" x1="0" y1="0" x2="-93.9726" y2="-31.4519" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009716" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009693" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.5007" x="112.574" y="40.4237" x1="0" y1="0" x2="0" y2="-11.1125" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009716" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009693" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50052" x="116.923" y="53.9519" x1="0" y1="0" x2="-93.9726" y2="-31.4519" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009716" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009693" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009716" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7111</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50053" x="53.9519" y="53.9519" x1="0" y1="0" x2="-31.0019" y2="-31.4519" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031976" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009709" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50074" x="112.574" y="29.3112" x1="0" y1="0" x2="-2.25471" y2="-2.25471" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031976" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009709" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50053" x="53.9519" y="53.9519" x1="0" y1="0" x2="-31.0019" y2="-31.4519" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031976" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009709" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009723" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7114</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50054" x="36.0753" y="44.9331" x1="0" y1="0" x2="-14.0253" y2="-13.4331" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032012" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009730" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50068" x="96.7913" y="53.9519" x1="0" y1="0" x2="-4.50941" y2="-4.50941" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032012" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009730" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50054" x="36.0753" y="44.9331" x1="0" y1="0" x2="-14.0253" y2="-13.4331" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032012" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009730" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009730" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7117</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50055" x="116.923" y="44.9331" x1="0" y1="0" x2="-80.8473" y2="0" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009723" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009702" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50067" x="108.065" y="53.9519" x1="0" y1="0" x2="-11.2735" y2="0" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009723" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009702" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50055" x="116.923" y="44.9331" x1="0" y1="0" x2="-80.8473" y2="0" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009723" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009702" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009737" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7120</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50056" x="104.522" y="11.1125" x1="0" y1="0" x2="-99.8513" y2="46.8657" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009744" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50077" x="103.95" y="13.5" x1="0" y1="0" x2="-4.904" y2="4.53765" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009744" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031886" layer="copper0"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50056" x="104.522" y="11.1125" x1="0" y1="0" x2="-99.8513" y2="46.8657" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009744" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009744" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7123</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50057" x="99.046" y="18.0376" x1="0" y1="0" x2="-94.096" y2="40.4624" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009751" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009737" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50078" x="99.046" y="18.0376" x1="0" y1="0" x2="-81.0084" y2="0" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009751" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009737" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50057" x="99.046" y="18.0376" x1="0" y1="0" x2="-94.096" y2="40.4624" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009751" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009737" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009751" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7126</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50058" x="18.0376" y="18.0376" x1="0" y1="0" x2="-13.0876" y2="40.4624" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009758" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009744" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50079" x="18.0376" y="18.0376" x1="0" y1="0" x2="-4.50941" y2="4.50941" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009758" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009744" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50058" x="18.0376" y="18.0376" x1="0" y1="0" x2="-13.0876" y2="40.4624" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009758" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009744" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009758" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7129</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50059" x="13.5282" y="22.5471" x1="0" y1="0" x2="-8.57823" y2="35.9529" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009765" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009751" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.5008" x="13.5282" y="22.5471" x1="0" y1="0" x2="0" y2="26.8954" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009765" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009751" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50059" x="13.5282" y="22.5471" x1="0" y1="0" x2="-8.57823" y2="35.9529" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009765" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009751" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009765" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7132</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.5006" x="9.01882" y="53.9519" x1="0" y1="0" x2="-4.06882" y2="4.54811" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009758" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50081" x="13.5282" y="49.4425" x1="0" y1="0" x2="-8.57823" y2="9.05752" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009413" layer="copper0"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009758" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.5006" x="9.01882" y="53.9519" x1="0" y1="0" x2="-4.06882" y2="4.54811" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009758" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009772" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7135</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50061" x="101.945" y="59.4276" x1="0" y1="0" x2="-96.3081" y2="-28.5059" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009779" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50066" x="103.05" y="58.5" x1="0" y1="0" x2="-8.5134" y2="-0.0387" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009779" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031886" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50061" x="101.945" y="59.4276" x1="0" y1="0" x2="-96.3081" y2="-28.5059" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009779" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009779" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7138</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50062" x="18.0376" y="53.9519" x1="0" y1="0" x2="-13.9876" y2="-22.4519" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032026" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009772" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50065" x="94.5366" y="58.4613" x1="0" y1="0" x2="-6.76412" y2="-6.76412" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032026" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009772" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50062" x="18.0376" y="53.9519" x1="0" y1="0" x2="-13.9876" y2="-22.4519" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032026" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009772" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009793" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7144</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50063" x="13.5282" y="40.4237" x1="0" y1="0" x2="-9.47823" y2="-8.92365" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009800" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50064" x="9.0189" y="36.0753" x1="0" y1="0" x2="-4.9689" y2="-4.5753" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009800" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50063" x="13.5282" y="40.4237" x1="0" y1="0" x2="-9.47823" y2="-8.92365" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009800" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009800" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7147</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50064" x="13.5282" y="49.4425" x1="0" y1="0" x2="0" y2="-9.01882" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009793" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032033" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50063" x="85.5178" y="36.0753" x1="0" y1="0" x2="-76.4989" y2="0" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009793" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032033" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50064" x="13.5282" y="49.4425" x1="0" y1="0" x2="0" y2="-9.01882" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009793" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032033" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009807" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7150</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50065" x="5.95887" y="23.5134" x1="0" y1="0" x2="97.4355" y2="8.69672" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009814" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50062" x="4.95" y="22.5" x1="0" y1="0" x2="4.06882" y2="4.5565" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009814" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50065" x="5.95887" y="23.5134" x1="0" y1="0" x2="97.4355" y2="8.69672" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009814" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009814" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7153</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50066" x="9.01882" y="27.0565" x1="0" y1="0" x2="94.0312" y2="4.44353" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009821" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009807" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50061" x="9.01882" y="27.0565" x1="0" y1="0" x2="90.0272" y2="0" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009821" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009807" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50066" x="9.01882" y="27.0565" x1="0" y1="0" x2="94.0312" y2="4.44353" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009821" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009807" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009821" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7156</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50067" x="99.046" y="27.0565" x1="0" y1="0" x2="4.004" y2="4.44353" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009814" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.5006" x="99.046" y="27.0565" x1="0" y1="0" x2="4.90398" y2="4.4435" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031886" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009814" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50067" x="99.046" y="27.0565" x1="0" y1="0" x2="4.004" y2="4.44353" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009814" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009830" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7159</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50068" x="7.08622" y="14.6556" x1="0" y1="0" x2="95.825" y2="34.6258" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009893" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50097" x="4.05" y="13.5" x1="0" y1="0" x2="4.96882" y2="4.5376" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009893" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50068" x="7.08622" y="14.6556" x1="0" y1="0" x2="95.825" y2="34.6258" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009893" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009837" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7162</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50069" x="3.54311" y="4.67046" x1="0" y1="0" x2="100.818" y2="34.7869" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009865" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50096" x="4.95" y="4.5" x1="0" y1="0" x2="4.06882" y2="4.51882" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009865" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50069" x="3.54311" y="4.67046" x1="0" y1="0" x2="100.818" y2="34.7869" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009865" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009844" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7165</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.5007" x="27.0565" y="62.9707" x1="0" y1="0" x2="4.50941" y2="4.50941" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009686" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009679" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50052" x="27.0565" y="62.9707" x1="0" y1="0" x2="4.50941" y2="4.50941" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009686" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009679" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.5007" x="27.0565" y="62.9707" x1="0" y1="0" x2="4.50941" y2="4.50941" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009686" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009679" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009851" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7168</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50071" x="36.0753" y="62.9707" x1="0" y1="0" x2="80.8473" y2="0" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009653" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009646" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50048" x="33.8206" y="62.9707" x1="0" y1="0" x2="83.102" y2="0" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009653" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009646" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50071" x="36.0753" y="62.9707" x1="0" y1="0" x2="80.8473" y2="0" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009653" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009646" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009865" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7174</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50072" x="9.01882" y="9.01882" x1="0" y1="0" x2="94.9312" y2="31.4812" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009872" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009837" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50095" x="9.01882" y="9.01882" x1="0" y1="0" x2="101.301" y2="0" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009872" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009837" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50072" x="9.01882" y="9.01882" x1="0" y1="0" x2="94.9312" y2="31.4812" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009872" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009837" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009872" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7177</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50073" x="99.046" y="9.01882" x1="0" y1="0" x2="4.904" y2="31.4812" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009879" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009865" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50094" x="110.32" y="9.01882" x1="0" y1="0" x2="4.50941" y2="4.50941" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009879" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009865" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50073" x="99.046" y="9.01882" x1="0" y1="0" x2="4.904" y2="31.4812" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009879" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009865" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009879" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7180</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50074" x="112.574" y="13.5282" x1="0" y1="0" x2="-8.62424" y2="26.9718" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009886" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009872" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50093" x="114.829" y="13.5282" x1="0" y1="0" x2="0" y2="22.5471" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009886" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009872" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50074" x="112.574" y="13.5282" x1="0" y1="0" x2="-8.62424" y2="26.9718" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009886" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009872" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009886" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7183</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50075" x="112.574" y="31.5659" x1="0" y1="0" x2="-8.62424" y2="8.93412" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031825" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009879" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50092" x="114.829" y="36.0753" x1="0" y1="0" x2="-4.50941" y2="4.34836" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031825" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009879" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50075" x="112.574" y="31.5659" x1="0" y1="0" x2="-8.62424" y2="8.93412" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031825" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009879" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009893" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7186</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50076" x="9.01882" y="9.01882" x1="0" y1="0" x2="94.0312" y2="40.4812" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009900" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009830" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50091" x="9.01882" y="18.0376" x1="0" y1="0" x2="99.046" y2="0" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009900" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009830" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50076" x="9.01882" y="9.01882" x1="0" y1="0" x2="94.0312" y2="40.4812" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009900" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009830" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009900" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7189</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50077" x="108.065" y="9.01882" x1="0" y1="0" x2="-5.01483" y2="40.4812" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009907" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009893" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.5009" x="108.065" y="18.0376" x1="0" y1="0" x2="2.25471" y2="2.25471" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009907" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009893" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50077" x="108.065" y="9.01882" x1="0" y1="0" x2="-5.01483" y2="40.4812" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009907" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009893" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009907" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7192</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50078" x="112.574" y="13.5282" x1="0" y1="0" x2="-9.52424" y2="35.9718" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031832" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009900" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50089" x="110.32" y="20.2924" x1="0" y1="0" x2="0" y2="13.5282" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031832" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009900" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50078" x="112.574" y="13.5282" x1="0" y1="0" x2="-9.52424" y2="35.9718" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031832" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009900" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86009914" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7195</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50079" x="112.574" y="40.4237" x1="0" y1="0" x2="-9.52424" y2="9.07635" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031927" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031839" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50088" x="96.7913" y="47.1878" x1="0" y1="0" x2="2.25471" y2="2.25471" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031927" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031839" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50079" x="112.574" y="40.4237" x1="0" y1="0" x2="-9.52424" y2="9.07635" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031927" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031839" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031811" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7231</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.5008" x="96.7913" y="36.0753" x1="0" y1="0" x2="0" y2="6.60307" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031839" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031818" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50087" x="99.046" y="36.0753" x1="0" y1="0" x2="-2.25471" y2="2.25471" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031839" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031818" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.5008" x="96.7913" y="36.0753" x1="0" y1="0" x2="0" y2="6.60307" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031839" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031818" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031818" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7234</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50081" x="105.81" y="36.0753" x1="0" y1="0" x2="-9.01882" y2="0" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031811" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031832" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50086" x="108.065" y="36.0753" x1="0" y1="0" x2="-9.01882" y2="0" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031811" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031832" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50081" x="105.81" y="36.0753" x1="0" y1="0" x2="-9.01882" y2="0" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031811" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031832" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031825" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7237</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50082" x="110.32" y="40.4237" x1="0" y1="0" x2="-6.36953" y2="0.076347" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009886" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50085" x="110.32" y="40.4237" x1="0" y1="0" x2="-7.26959" y2="0.07634" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031886" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009886" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50082" x="110.32" y="40.4237" x1="0" y1="0" x2="-6.36953" y2="0.076347" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009886" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031832" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7240</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50083" x="108.065" y="33.8206" x1="0" y1="0" x2="-2.25471" y2="2.25471" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031818" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009907" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50084" x="110.32" y="33.8206" x1="0" y1="0" x2="-2.25471" y2="2.25471" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031818" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009907" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50083" x="108.065" y="33.8206" x1="0" y1="0" x2="-2.25471" y2="2.25471" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031818" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009907" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031839" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7243</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50084" x="96.7913" y="38.33" x1="0" y1="0" x2="0" y2="4.34836" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009914" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031811" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50083" x="96.7913" y="38.33" x1="0" y1="0" x2="0" y2="8.85777" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009914" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031811" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50084" x="96.7913" y="38.33" x1="0" y1="0" x2="0" y2="4.34836" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009914" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031811" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031846" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7246</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50085" x="105.166" y="22.225" x1="0" y1="0" x2="14.8166" y2="9.17987" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031853" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50098" x="103.05" y="22.5" x1="0" y1="0" x2="9.524" y2="0.0471" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031853" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031886" layer="copper0"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50085" x="105.166" y="22.225" x1="0" y1="0" x2="14.8166" y2="9.17987" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031853" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031853" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7249</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50086" x="112.574" y="22.5471" x1="0" y1="0" x2="8.47576" y2="8.95294" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031846" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50099" x="112.574" y="22.5471" x1="0" y1="0" x2="8.47576" y2="8.95294" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009422" layer="copper0"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031846" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50086" x="112.574" y="22.5471" x1="0" y1="0" x2="8.47576" y2="8.95294" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031846" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="generic_female_alternating_pin_header_8_100mil_hs_0.9mm_0.4mm" modelIndex="86031860" path="/home/sheep/.config/Fritzing/partfactory/bbf9f808e12917fe4cff3a2a03d46965/core/generic_female_alternating_pin_header_8_100mil_hs_0.9mm_0.4mm.fzp">
+            <property name="hole size" value="0.9mm,0.4mm"/>
+            <property name="form" value="♀ (female)"/>
+            <title>5V GND D4 D3 D2 D1 -- --</title>
+            <views>
+                <breadboardView layer="breadboard">
+                    <geometry z="2.501" x="211.503" y="58.5015"/>
+                    <connectors>
+                        <connector connectorId="connector4" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031962" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032498" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector2" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031969" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032566" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector7" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031920" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032465" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector3" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031944" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032554" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector6" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009639" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032479" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector5" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031955" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032494" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0" bottom="true">
+                    <geometry z="5.50103" x="16.2" y="-1.8"/>
+                    <titleGeometry visible="true" x="-1.33567" y="88.7965" z="13.0039" xOffset="-17.5357" yOffset="90.5965" textColor="#444444" fontSize="3">
+                        <transform m11="0" m12="-1" m13="0" m21="-1" m22="0" m23="0" m31="32.5" m32="-19.5" m33="1"/>
+                        <displayKey key=""/>
+                    </titleGeometry>
+                    <connectors>
+                        <connector connectorId="connector2" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031969" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector3" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032554" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector6" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009639" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematic">
+                    <geometry z="2.501" x="17.9738" y="-139.51">
+                        <transform m11="-1" m12="0" m13="0" m21="0" m22="1" m23="0" m31="18" m32="0" m33="1"/>
+                    </geometry>
+                    <titleGeometry visible="true" x="-22.5145" y="-152.034" z="7.00402" xOffset="-40.4883" yOffset="-12.5239" textColor="#000000" fontSize="5">
+                        <displayKey key=""/>
+                        <displayKey key="part number"/>
+                    </titleGeometry>
+                    <connectors>
+                        <connector connectorId="connector4" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031962" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032498" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector2" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031969" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032566" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector7" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031920" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032465" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector3" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031944" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032554" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector6" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009639" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032479" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector5" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031955" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032494" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="generic_female_alternating_pin_header_8_100mil_hs_0.9mm_0.4mm" modelIndex="86031886" path="/home/sheep/.config/Fritzing/partfactory/bbf9f808e12917fe4cff3a2a03d46965/core/generic_female_alternating_pin_header_8_100mil_hs_0.9mm_0.4mm.fzp">
+            <property name="hole size" value="0.9mm,0.4mm"/>
+            <property name="form" value="♀ (female)"/>
+            <title>3V D8 D7 D6 D5 D0 A0 RST</title>
+            <views>
+                <breadboardView layer="breadboard">
+                    <geometry z="2.50099" x="211.503" y="-4.49854"/>
+                    <connectors>
+                        <connector connectorId="connector4" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031825" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032579" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector2" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031846" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032445" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector7" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009686" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032458" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector1" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009737" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032505" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector3" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009821" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032541" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009535" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032437" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector6" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009772" layer="breadboardWire"/>
+                                <connect connectorId="connector0" modelIndex="86032518" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector5" layer="breadboard">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031927" layer="breadboardWire"/>
+                                <connect connectorId="connector1" modelIndex="86032598" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0" bottom="true">
+                    <geometry z="5.50102" x="97.2" y="-1.8"/>
+                    <titleGeometry visible="true" x="61.6267" y="90.246" z="13.0039" xOffset="-35.5733" yOffset="92.046" textColor="#444444" fontSize="3">
+                        <transform m11="0" m12="-1" m13="0" m21="-1" m22="0" m23="0" m31="35.5" m32="-22.5" m33="1"/>
+                        <displayKey key=""/>
+                    </titleGeometry>
+                    <connectors>
+                        <connector connectorId="connector2" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031846" layer="copper0trace"/>
+                                <connect connectorId="connector1" modelIndex="86032445" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector7" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009686" layer="copper0trace"/>
+                                <connect connectorId="connector1" modelIndex="86032458" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector1" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009737" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector3" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032541" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector5" layer="copper0">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032598" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematic">
+                    <geometry z="2.50099" x="89.9737" y="-139.51"/>
+                    <titleGeometry visible="true" x="90.4273" y="-153.984" z="7.00403" xOffset="0.453512" yOffset="-14.4735" textColor="#000000" fontSize="5">
+                        <displayKey key=""/>
+                        <displayKey key="part number"/>
+                    </titleGeometry>
+                    <connectors>
+                        <connector connectorId="connector4" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031825" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032579" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector2" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031846" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032445" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector7" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009686" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032458" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector1" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009737" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032505" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector3" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009821" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032541" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009535" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032437" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector6" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009772" layer="schematicTrace"/>
+                                <connect connectorId="connector0" modelIndex="86032518" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector5" layer="schematic">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031927" layer="schematicTrace"/>
+                                <connect connectorId="connector1" modelIndex="86032598" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031920" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7280</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50087" x="94.5366" y="67.4801" x1="0" y1="0" x2="-71.5866" y2="0.0198781" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009632" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50042" x="94.5366" y="67.4801" x1="0" y1="0" x2="-71.5866" y2="0.01989" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031860" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009632" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50087" x="94.5366" y="67.4801" x1="0" y1="0" x2="-71.5866" y2="0.0198781" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009632" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031927" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7283</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50088" x="99.046" y="49.4425" x1="0" y1="0" x2="4.904" y2="0.057524" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009914" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50082" x="99.046" y="49.4425" x1="0" y1="0" x2="4.90399" y2="0.05749" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031886" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009914" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50088" x="99.046" y="49.4425" x1="0" y1="0" x2="4.904" y2="0.057524" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009914" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031944" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7290</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50089" x="29.3112" y="31.5659" x1="0" y1="0" x2="-6.36117" y2="-0.0658804" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032019" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50059" x="87.7725" y="31.5659" x1="0" y1="0" x2="-64.8225" y2="-0.06589" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031860" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032019" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50089" x="29.3112" y="31.5659" x1="0" y1="0" x2="-6.36117" y2="-0.0658804" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032019" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031955" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7295</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.5009" x="19.0039" y="48.9593" x1="0" y1="0" x2="-14.6556" y2="0" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50101" x="22.95" y="49.5" x1="0" y1="0" x2="-18.9" y2="-1.42109e-14" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031860" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.5009" x="19.0039" y="48.9593" x1="0" y1="0" x2="-14.6556" y2="0" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031962" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7298</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50091" x="20.9366" y="40.5847" x1="0" y1="0" x2="-14.6556" y2="-0.644202" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.501" x="22.05" y="40.5" x1="0" y1="0" x2="-17.1" y2="-1.42109e-14" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031860" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50091" x="20.9366" y="40.5847" x1="0" y1="0" x2="-14.6556" y2="-0.644202" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031969" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7301</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50092" x="87.7725" y="22.5471" x1="0" y1="0" x2="-65.7225" y2="-0.0470574" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031994" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50073" x="94.5366" y="22.5471" x1="0" y1="0" x2="-72.4866" y2="-0.0470574" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031860" layer="copper0"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031994" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50092" x="87.7725" y="22.5471" x1="0" y1="0" x2="-65.7225" y2="-0.0470574" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031994" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031976" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7304</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50093" x="96.7913" y="51.6972" x1="0" y1="0" x2="-29.3112" y2="-29.1501" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031994" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009716" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50072" x="110.32" y="27.0565" x1="0" y1="0" x2="-11.2735" y2="0" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031994" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009716" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50093" x="96.7913" y="51.6972" x1="0" y1="0" x2="-29.3112" y2="-29.1501" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031994" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009716" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86031994" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7312</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50094" x="99.046" y="27.0565" x1="0" y1="0" x2="-71.9895" y2="0" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031969" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031976" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper0trace" bottom="true">
+                    <geometry z="6.50071" x="99.046" y="27.0565" x1="0" y1="0" x2="-4.50941" y2="-4.50941" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f28a00" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031969" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper0trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031976" layer="copper0trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50094" x="99.046" y="27.0565" x1="0" y1="0" x2="-71.9895" y2="0" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031969" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031976" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032012" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7320</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50095" x="92.2819" y="49.4425" x1="0" y1="0" x2="-18.0376" y2="-17.8766" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032019" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009723" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50058" x="92.2819" y="49.4425" x1="0" y1="0" x2="0" y2="-13.3672" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032019" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009723" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50095" x="92.2819" y="49.4425" x1="0" y1="0" x2="-18.0376" y2="-17.8766" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032019" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009723" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032019" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7323</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50096" x="92.2819" y="33.8206" x1="0" y1="0" x2="-18.0376" y2="-2.25471" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031944" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032012" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50057" x="92.2819" y="36.0753" x1="0" y1="0" x2="-4.50941" y2="-4.50941" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031944" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032012" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50096" x="92.2819" y="33.8206" x1="0" y1="0" x2="-18.0376" y2="-2.25471" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031944" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032012" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032026" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7326</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50097" x="85.5178" y="49.4425" x1="0" y1="0" x2="-13.5282" y2="-13.3672" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032033" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009779" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50056" x="87.7725" y="51.6972" x1="0" y1="0" x2="0" y2="-13.3672" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032033" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009779" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50097" x="85.5178" y="49.4425" x1="0" y1="0" x2="-13.5282" y2="-13.3672" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032033" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009779" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032033" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7329</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50098" x="85.5178" y="38.33" x1="0" y1="0" x2="-13.5282" y2="-2.25471" wireFlags="4"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009800" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032026" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50055" x="87.7725" y="38.33" x1="0" y1="0" x2="-2.25471" y2="-2.25471" wireFlags="4"/>
+                    <wireExtras mils="16" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009800" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032026" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50098" x="85.5178" y="38.33" x1="0" y1="0" x2="-13.5282" y2="-2.25471" wireFlags="4"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009800" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032026" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="newSilkscreen0LogoImageModuleID" modelIndex="86032050" path=":/resources/parts/core/newsilkscreen0logoimage.fzp">
+            <property name="width" value="13.61418728312133"/>
+            <property name="height" value="18.181025839413827"/>
+            <property name="shape" value="&lt;?xml version='1.0' encoding='UTF-8' standalone='no'?&gt;&#10;&lt;!-- Created with Fritzing (http://www.fritzing.org/) --&gt;&#10;&lt;svg xmlns=&quot;http://www.w3.org/2000/svg&quot; x=&quot;0in&quot; width=&quot;0.535992in&quot; version=&quot;1.2&quot; id=&quot;svg2&quot; y=&quot;0in&quot; height=&quot;0.715788in&quot;  viewBox=&quot;0 0 69.46409 92.765612&quot;&gt;&#10; &lt;g id=&quot;silkscreen0&quot; transform=&quot;matrix(-1, 0, 0, 1, 69.4641, 0)&quot; _flipped_=&quot;1&quot;&gt;&#10;  &lt;metadata id=&quot;metadata4082&quot;&gt;&#10;   &lt;rdf:RDF xmlns:rdf=&quot;http://www.w3.org/1999/02/22-rdf-syntax-ns#&quot;&gt;&#10;    &lt;cc:Work rdf:about=&quot;&quot; xmlns:rdf=&quot;http://www.w3.org/1999/02/22-rdf-syntax-ns#&quot; xmlns:cc=&quot;http://creativecommons.org/ns#&quot;&gt;&#10;     &lt;dc:format xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot;&gt;image/svg+xml&lt;/dc:format&gt;&#10;     &lt;dc:type rdf:resource=&quot;http://purl.org/dc/dcmitype/StillImage&quot; xmlns:rdf=&quot;http://www.w3.org/1999/02/22-rdf-syntax-ns#&quot; xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot;/&gt;&#10;     &lt;dc:title xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot;/&gt;&#10;    &lt;/cc:Work&gt;&#10;   &lt;/rdf:RDF&gt;&#10;  &lt;/metadata&gt;&#10;  &lt;defs id=&quot;defs4080&quot;/&gt;&#10;  &lt;path id=&quot;xxx&quot; stroke=&quot;none&quot; fill=&quot;#444444&quot; style=&quot;stroke-miterlimit:4;stroke-dasharray:none&quot; d=&quot;m 0,71.248452 c 0,0.191379 0.09551,0.382435 0.285937,0.478125 l 4.776563,2.2 c 0.191379,0.09569 0.285937,0.286746 0.285937,0.478125 v 16.448437 c 0.192321,1.05163 1.05246,1.9125 2.103125,1.9125 h 12.989063 c 0.286112,0 0.573438,-0.286377 0.573438,-0.573437 v -2.2 c 0,-0.47845 0.381303,-0.765625 0.764062,-0.765625 h 22.254687 c 0.477492,0 0.859376,0.382865 0.859376,0.765625 v 2.2 c 0,0.28706 0.286368,0.573437 0.573437,0.573437 h 22.064063 c 1.050673,0 1.910937,-0.859911 1.910937,-1.9125 v -0.110937 l 0.02344,-0.02344 v -1.19531 l -0.02344,0.02344 v -5.089063 l 0.02344,-0.02344 v -1.19375 l -0.02344,0.02344 v -5.092187 l 0.02344,-0.02344 v -1.19375 l -0.02344,0.02344 V 71.88908 l 0.02344,-0.02344 v -1.196874 l -0.02344,0.02344 v -5.089064 l 0.02344,-0.02344 v -1.19375 l -0.02344,0.02344 v -5.090625 l 0.02344,-0.02344 v -1.195313 l -0.02344,0.02344 v -5.089062 l 0.02344,-0.02344 v -1.195313 l -0.02344,0.02344 v -5.089063 l 0.02344,-0.02344 v -1.195312 l -0.02344,0.02344 v -5.090625 l 0.02344,-0.02344 v -1.192187 l -0.02344,0.02344 v -5.092188 l 0.02344,-0.02344 v -1.193751 l -0.02344,0.02344 v -5.089062 l 0.02344,-0.02344 v -1.195313 l -0.02344,0.02344 v -5.090626 l 0.02344,-0.02344 v -1.192187 l -0.02344,0.02344 v -5.092188 l 0.02344,-0.02344 v -1.192185 l -0.02344,0.02344 V 12.24064 c 0,-0.9852 -0.128617,-1.936856 -0.345312,-2.853128 l 0.0078,-0.0078 c -0.03233,-0.13712 -0.07565,-0.269496 -0.1125,-0.404688 -0.0447,-0.163376 -0.08477,-0.328552 -0.135938,-0.489064 -0.0041,-0.01283 -0.0068,-0.02625 -0.01094,-0.03906 L 68.840635,8.45 C 67.255665,3.532432 62.671558,0 57.214073,0 H 12.226564 C 5.540763,0 2e-6,5.4504879 2e-6,12.240624 Z M 0.551562,70.453139 V 65.360952 L 19.371875,46.540639 63.504688,2.409392 c 1.018856,0.655904 1.933365,1.457952 2.703125,2.389056 L 21.91875,49.085952 Z m 0,-6.284374 V 59.076577 L 19.371875,40.254702 58.935937,0.6922 c 1.364809,0.203416 2.657826,0.630864 3.826563,1.265624 L 21.91875,42.801577 Z m 0,-6.284375 V 52.792202 L 19.371875,33.97189 52.795312,0.550016 h 4.418751 c 0.215692,0 0.426217,0.02119 0.639062,0.03281 L 21.91875,36.517202 Z m 0,-6.284376 V 46.507827 L 19.371875,27.687514 46.509375,0.550016 h 5.092187 L 21.91875,30.232827 Z m 0,-6.285937 V 40.223452 L 19.371875,21.401577 40.225,0.550016 h 5.090625 L 21.91875,23.94689 Z m 0,-6.284375 V 33.939077 L 13.089063,21.401577 33.940625,0.550016 H 39.03125 L 15.634375,23.94689 Z m 0,-6.285937 V 27.654702 L 6.804688,21.401577 27.65625,0.550016 h 5.090625 L 9.348437,23.94689 Z m 0,-6.282813 V 21.368765 L 21.371875,0.550016 H 26.4625 L 3.065625,23.94689 Z m 0,-6.284375 V 15.085952 L 15.0875,0.550016 h 5.090625 z m 0,-6.282809 V 12.24064 c 0,-1.499944 0.293039,-2.92952 0.809375,-4.24844 L 7.996875,1.356264 C 9.31022,0.842712 10.733767,0.550016 12.226562,0.550016 H 13.89375 Z M 0.825,71.373452 25.657812,46.540639 66.71875,5.478136 c 0.732807,1.029616 1.306156,2.178464 1.676563,3.417192 L 28.203125,49.085952 4.314062,72.975014 Z M 2.834375,5.325016 C 3.536676,4.371448 4.377987,3.530168 5.33125,2.828136 Z M 5.13125,73.350014 31.942188,46.540639 68.640625,9.8422 c 0.161957,0.774512 0.248438,1.57648 0.248438,2.39844 v 2.445312 l -34.401563,34.4 -28.589063,28.590625 v -3.271875 c 0,-0.417207 -0.226361,-0.790223 -0.60625,-0.979688 z m 0.767187,16.895313 v -5.092188 l 38.6125,-38.6125 24.378126,-24.378125 v 5.090625 L 47.05625,49.085952 Z m 0,-6.285937 v -5.092188 l 32.328125,-32.326563 30.662501,-30.6625 v 5.092188 L 40.773437,49.085952 Z m 0.16875,7.310937 38.44375,-38.44375 24.378126,-24.378125 v 5.089062 L 47.05625,55.370327 10.2125,92.214077 H 7.451562 c -0.574374,0 -1.104114,-0.383157 -1.384375,-0.94375 z m 5.340625,0.94375 L 44.510937,59.10939 68.889063,34.731265 v 5.092187 L 47.05625,61.656265 16.498437,92.214077 Z m 6.284376,0 3.159374,-3.159375 c -0.23202,0.225037 -0.389062,0.541818 -0.389062,0.9375 l 0.0031,2.175 c -0.0057,0.01627 -0.03361,0.04305 -0.025,0.04687 z M 20.889063,89.015639 44.510937,65.393765 68.889063,41.015639 v 5.090626 L 47.05625,67.939077 26.321875,88.675014 h -4.54375 c -0.318782,0 -0.642279,0.120612 -0.889062,0.340625 z M 27.515625,88.675014 44.510937,71.679702 68.889063,47.301577 v 5.089062 L 47.05625,74.223452 32.604688,88.675014 Z m 6.284375,0 16.996875,-16.995312 18.092188,-18.09375 v 5.089062 L 53.340625,74.223452 38.889063,88.675014 Z m 6.284375,0 16.995313,-16.995312 11.809375,-11.809375 v 5.090625 l -9.262501,9.2625 -14.737499,14.7375 C 44.649136,88.7854 44.353224,88.675014 44.032812,88.675014 Z m 5.304688,0.979688 17.975,-17.975 5.525,-5.525 v 5.089063 l -2.979688,2.979687 -17.99375,17.99375 h -2.426562 c -0.01435,-0.0057 -0.03706,-0.02656 -0.04375,-0.02656 0,0 -0.0016,0.0016 -0.0016,0.0016 v -2.2 c 0,-0.116477 -0.02259,-0.229071 -0.05469,-0.3375 z m 3.721874,2.5625 19.778126,-19.776563 v 5.089063 L 54.203125,92.215639 Z m 6.285938,-0.0016 13.492188,-13.492187 v 5.092187 l -8.4,8.4 z m 6.285938,0 7.20625,-7.20625 v 5.089063 l -2.115626,2.115625 z m 6.4125,-0.128125 0.664062,-0.664062 c -0.135874,0.292977 -0.371303,0.52871 -0.664062,0.664062 z&quot; stroke-width=&quot;1.27999997&quot;/&gt;&#10; &lt;/g&gt;&#10;&lt;/svg&gt;&#10;"/>
+            <property name="lastfilename" value="/home/sheep/dev/hardware/d1-mini-xpad/d1mini.svg"/>
+            <property name="originalWidth" value="24.505387107999997"/>
+            <property name="originalHeight" value="32.725667339999994"/>
+            <title>IMG1</title>
+            <views>
+                <pcbView layer="silkscreen0">
+                    <geometry z="3.50041" x="38.8832" y="3.85034"/>
+                </pcbView>
+            </views>
+        </instance>
+        <instance moduleIdRef="newCopper0LogoImageModuleID" modelIndex="86032055" path=":/resources/parts/core/newcopper0logoimage.fzp">
+            <property name="width" value="8.835421571718001"/>
+            <property name="height" value="9.895701240688073"/>
+            <property name="shape" value="&lt;?xml version='1.0' encoding='UTF-8' standalone='no'?&gt;&#10;&lt;!-- Created with Inkscape (http://www.inkscape.org/) --&gt;&#10;&lt;svg xmlns=&quot;http://www.w3.org/2000/svg&quot; width=&quot;0.347851in&quot; version=&quot;1.1&quot; id=&quot;svg8&quot; height=&quot;0.389595in&quot;  viewBox=&quot;0 0 63.5 71.120209&quot;&gt;&#10; &lt;g id=&quot;copper0&quot; transform=&quot;matrix(-1, 0, 0, 1, 63.5, 0)&quot; _flipped_=&quot;1&quot;&gt;&#10;  &lt;defs id=&quot;defs2&quot;/&gt;&#10;  &lt;metadata id=&quot;metadata5&quot;&gt;&#10;   &lt;rdf:RDF xmlns:rdf=&quot;http://www.w3.org/1999/02/22-rdf-syntax-ns#&quot;&gt;&#10;    &lt;cc:Work rdf:about=&quot;&quot; xmlns:rdf=&quot;http://www.w3.org/1999/02/22-rdf-syntax-ns#&quot; xmlns:cc=&quot;http://creativecommons.org/ns#&quot;&gt;&#10;     &lt;dc:format xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot;&gt;image/svg+xml&lt;/dc:format&gt;&#10;     &lt;dc:type rdf:resource=&quot;http://purl.org/dc/dcmitype/StillImage&quot; xmlns:rdf=&quot;http://www.w3.org/1999/02/22-rdf-syntax-ns#&quot; xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot;/&gt;&#10;     &lt;dc:title xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot;/&gt;&#10;    &lt;/cc:Work&gt;&#10;   &lt;/rdf:RDF&gt;&#10;  &lt;/metadata&gt;&#10;  &lt;g transform=&quot;translate(-12.7,-4.8999592)&quot;&gt;&#10;   &lt;g id=&quot;layer1&quot;&gt;&#10;    &lt;g transform=&quot;scale(0.26458333)&quot;&gt;&#10;     &lt;path fill-opacity=&quot;1.0&quot; stroke-opacity=&quot;1.0&quot; id=&quot;rect4487&quot; stroke=&quot;none&quot; fill=&quot;#f9a435&quot; style=&quot;opacity:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;&quot; d=&quot;m 96,18.519531 c -26.592,0 -48,21.408003 -48,48 V 210.51953 c 0,26.592 21.408,48 48,48 v 19.19922 c 0,5.3184 4.28121,9.60156 9.59961,9.60156 h 9.59961 c 5.3184,0 9.60156,-4.28316 9.60156,-9.60156 v -19.19922 h 9.59961 v 19.19922 c 0,5.3184 4.28121,9.60156 9.59961,9.60156 h 9.59961 c 5.3184,0 9.59961,-4.28316 9.59961,-9.60156 v -19.19922 h 9.60156 v 19.19922 c 0,5.3184 4.28121,9.60156 9.59961,9.60156 H 192 c 5.3184,0 9.59961,-4.28316 9.59961,-9.60156 v -19.19922 h 9.59961 v 19.19922 c 0,5.3184 4.28316,9.60156 9.60156,9.60156 h 9.59961 c 5.3184,0 9.59961,-4.28316 9.59961,-9.60156 v -19.19922 c 26.592,0 48,-21.408 48,-48 V 66.519531 c 0,-26.591997 -21.408,-48 -48,-48 z m 5.75977,9.59961 h 132.48046 c 24.46464,0 44.16016,19.695518 44.16016,44.160156 V 204.75977 c 0,24.46463 -19.69552,44.16015 -44.16016,44.16015 H 101.75977 c -24.464648,0 -44.160161,-19.69552 -44.160161,-44.16015 V 72.279297 c 0,-24.464638 19.695513,-44.160156 44.160161,-44.160156 z M 97.919922,85.71875 c -17.018879,0 -30.720703,13.701831 -30.720703,30.7207 v 92.16016 c 0,17.01888 13.701824,30.7207 30.720703,30.7207 h 92.160158 c 17.01888,0 30.7207,-13.70182 30.7207,-30.7207 v -92.16016 c 0,-17.018869 -13.70182,-30.7207 -30.7207,-30.7207 z m 26.501958,28.80078 h 0.75585 c 5.10868,0 9.22266,4.28121 9.22266,9.59961 v 38.40039 c 0,5.3184 -4.11398,9.59961 -9.22266,9.59961 h -0.75585 c -5.10868,0 -9.22266,-4.28121 -9.22266,-9.59961 v -38.40039 c 0,-5.3184 4.11398,-9.59961 9.22266,-9.59961 z m 38.40039,0 h 0.75585 c 5.10868,0 9.22266,4.28121 9.22266,9.59961 v 38.40039 c 0,5.3184 -4.11398,9.59961 -9.22266,9.59961 h -0.75585 c -5.10868,0 -9.22266,-4.28121 -9.22266,-9.59961 v -38.40039 c 0,-5.3184 4.11398,-9.59961 9.22266,-9.59961 z&quot; stroke-width=&quot;7.55905533&quot;/&gt;&#10;    &lt;/g&gt;&#10;   &lt;/g&gt;&#10;  &lt;/g&gt;&#10; &lt;/g&gt;&#10;&lt;/svg&gt;&#10;"/>
+            <property name="lastfilename" value="/home/sheep/Pictures/logo/deshipu-logo.svg"/>
+            <property name="originalWidth" value="63.5"/>
+            <property name="originalHeight" value="71.120209"/>
+            <title>IMG2</title>
+            <views>
+                <pcbView layer="copper0">
+                    <geometry z="5.5004" x="46.7051" y="26.0168"/>
+                </pcbView>
+            </views>
+        </instance>
+        <instance moduleIdRef="newCopper1LogoImageModuleID" modelIndex="86032060" path=":/resources/parts/core/newcopper1logoimage.fzp">
+            <property name="width" value="12.933097558983995"/>
+            <property name="height" value="5.781855379310493"/>
+            <property name="shape" value="&lt;?xml version='1.0' encoding='utf-8'?&gt;&#10;&lt;!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'&gt;&#10;&lt;!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  --&gt;&#10;&lt;svg xmlns=&quot;http://www.w3.org/2000/svg&quot; x=&quot;0px&quot; width=&quot;0.509177in&quot; version=&quot;1.1&quot; id=&quot;Layer_1&quot; y=&quot;0px&quot; enable-background=&quot;new 0 0 85 38&quot; height=&quot;0.227632in&quot; xml:space=&quot;preserve&quot;  xmlns:xml=&quot;http://www.w3.org/XML/1998/namespace&quot; viewBox=&quot;0 0 85 38&quot;&gt;&#10; &lt;g id=&quot;copper1&quot;&gt;&#10;  &lt;g id=&quot;silkscreen0&quot;&gt;&#10;   &lt;g&gt;&#10;    &lt;g&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M48.063,27.241c-0.831,0-1.559,0.449-1.959,1.114h-3.852l5.457-5.61c0.203-0.201,0.4-0.444,0.589-0.72c0.207-0.306,0.314-0.66,0.314-1.058c0-0.385-0.134-0.714-0.396-0.977c-0.263-0.264-0.613-0.396-1.039-0.396h-6.39c-0.419,0-0.764,0.079-1.023,0.233c-0.301,0.18-0.454,0.507-0.454,0.974c0,0.454,0.153,0.775,0.454,0.954c0.26,0.154,0.604,0.232,1.023,0.232h4.342l-5.479,5.632c-0.199,0.202-0.397,0.436-0.585,0.694c-0.212,0.292-0.318,0.648-0.318,1.061c0,0.387,0.134,0.716,0.396,0.979s0.611,0.396,1.041,0.396h5.946c0.406,0.641,1.12,1.067,1.932,1.067c1.263,0,2.288-1.024,2.288-2.288C50.352,28.269,49.326,27.241,48.063,27.241z M48.063,30.568c-0.572,0-1.038-0.465-1.038-1.039c0-0.573,0.466-1.039,1.038-1.039c0.574,0,1.042,0.466,1.042,1.039C49.105,30.104,48.638,30.568,48.063,30.568z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M24.713,13.401c-1.26,0-2.288,1.026-2.288,2.288c0,1.263,1.027,2.288,2.288,2.288c1.262,0,2.288-1.025,2.288-2.288C27.001,14.428,25.975,13.401,24.713,13.401z M24.713,16.729c-0.574,0-1.039-0.465-1.039-1.039s0.465-1.039,1.039-1.039s1.041,0.465,1.041,1.039S25.287,16.729,24.713,16.729z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M36.457,19.825c-0.266-0.151-0.606-0.23-1.009-0.23h-2.02V16.12c0-0.403-0.077-0.743-0.229-1.009c-0.124-0.215-0.391-0.47-0.956-0.47c-0.469,0-0.797,0.158-0.977,0.47c-0.152,0.266-0.23,0.604-0.23,1.009v3.475h-0.664c-0.405,0-0.744,0.079-1.009,0.23c-0.312,0.181-0.47,0.508-0.47,0.977c0,0.566,0.255,0.832,0.47,0.955c0.266,0.153,0.604,0.23,1.009,0.23h0.664v6.014c0,0.379,0.037,0.733,0.111,1.055c0.076,0.341,0.216,0.64,0.41,0.89c0.199,0.254,0.474,0.456,0.82,0.597c0.333,0.137,0.766,0.206,1.28,0.206h1.236c0.401,0,0.741-0.077,1.008-0.229c0.213-0.123,0.468-0.389,0.468-0.957c0-0.467-0.157-0.797-0.468-0.975c-0.267-0.154-0.606-0.231-1.008-0.231h-1.132c-0.189,0-0.265-0.026-0.286-0.038c-0.02-0.046-0.048-0.139-0.048-0.317v-6.013h2.02c0.405,0,0.744-0.078,1.009-0.231c0.213-0.122,0.469-0.388,0.469-0.955C36.926,20.333,36.768,20.006,36.457,19.825z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M24.806,19.595h-1.645c-0.402,0-0.743,0.079-1.008,0.23c-0.311,0.181-0.469,0.508-0.469,0.977c0,0.566,0.256,0.832,0.469,0.954c0.265,0.154,0.605,0.231,1.008,0.231h0.749v7.388c0,0.405,0.079,0.744,0.231,1.01c0.18,0.311,0.508,0.469,0.976,0.469c0.567,0,0.833-0.256,0.956-0.469c0.153-0.267,0.23-0.605,0.23-1.01v-8.282c0-0.531-0.115-0.905-0.353-1.145C25.711,19.711,25.337,19.595,24.806,19.595z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M19.517,19.825c-0.266-0.151-0.607-0.23-1.009-0.23h-0.832c-0.344,0-0.686,0.086-1.012,0.257c-0.312,0.164-0.597,0.374-0.849,0.625l-0.887,0.831v-0.34c0-0.403-0.078-0.742-0.231-1.009c-0.18-0.311-0.509-0.468-0.977-0.468c-0.566,0-0.832,0.254-0.955,0.468c-0.153,0.267-0.23,0.605-0.23,1.009v6.615c-0.653,0.403-1.091,1.124-1.091,1.946c0,1.263,1.027,2.288,2.287,2.288c1.262,0,2.288-1.024,2.288-2.288c0-0.822-0.438-1.543-1.091-1.946v-3.048l2.394-2.154c0.139-0.125,0.275-0.226,0.41-0.299c0.116-0.063,0.24-0.095,0.379-0.095h0.396c0.404,0,0.743-0.077,1.009-0.231c0.213-0.122,0.469-0.388,0.469-0.954C19.986,20.333,19.828,20.006,19.517,19.825z M13.731,30.568c-0.573,0-1.039-0.465-1.039-1.039c0-0.573,0.466-1.039,1.039-1.039c0.574,0,1.041,0.466,1.041,1.039C14.772,30.104,14.305,30.568,13.731,30.568z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M10.262,14.978c-0.267-0.153-0.606-0.231-1.008-0.231H8.442c-0.276,0-0.538,0.008-0.775,0.021c-0.242,0.014-0.477,0.049-0.698,0.1c-0.231,0.055-0.461,0.147-0.684,0.278c-0.217,0.127-0.438,0.303-0.661,0.523c-0.461,0.433-0.763,0.904-0.899,1.403c-0.13,0.479-0.195,1.012-0.195,1.585v0.938H3.863c-0.402,0-0.742,0.079-1.007,0.23c-0.311,0.181-0.47,0.508-0.47,0.977c0,0.566,0.256,0.832,0.47,0.955c0.265,0.153,0.605,0.23,1.007,0.23H4.53v7.388c0,0.405,0.077,0.744,0.23,1.01c0.179,0.311,0.506,0.469,0.976,0.469c0.566,0,0.833-0.256,0.955-0.469c0.152-0.267,0.231-0.605,0.231-1.01v-7.388h1.269c0.404,0,0.744-0.077,1.01-0.231c0.213-0.122,0.468-0.388,0.468-0.954c0-0.469-0.158-0.797-0.468-0.977c-0.266-0.151-0.606-0.23-1.01-0.23H6.922v-0.938c0-0.298,0.026-0.563,0.077-0.787c0.045-0.193,0.143-0.357,0.301-0.506l0.002-0.004l0.004-0.003c0.112-0.111,0.242-0.173,0.399-0.188c0.206-0.021,0.468-0.029,0.777-0.029h0.771c0.402,0,0.743-0.079,1.008-0.231c0.213-0.122,0.469-0.39,0.469-0.956C10.73,15.485,10.572,15.156,10.262,14.978z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M81.923,19.959c-0.123-0.214-0.39-0.468-0.955-0.468c-0.469,0-0.798,0.157-0.975,0.468c-0.107,0.185-0.179,0.405-0.211,0.658l-0.028-0.029c-0.298-0.325-0.644-0.578-1.028-0.743c-0.385-0.166-0.778-0.25-1.172-0.25h-0.976c-0.343,0-0.64,0.019-0.882,0.056c-0.249,0.038-0.484,0.102-0.703,0.192c-0.217,0.09-0.429,0.206-0.631,0.349c-0.192,0.136-0.419,0.312-0.671,0.522c-0.259,0.216-0.473,0.415-0.639,0.597c-0.177,0.191-0.318,0.403-0.419,0.628c-0.099,0.222-0.169,0.464-0.206,0.722c-0.037,0.245-0.054,0.537-0.054,0.868v3.288c0,0.331,0.017,0.622,0.054,0.869c0.037,0.257,0.107,0.499,0.206,0.721c0.101,0.226,0.242,0.437,0.419,0.629c0.165,0.18,0.38,0.38,0.639,0.595c0.255,0.213,0.481,0.388,0.671,0.522c0.201,0.143,0.412,0.259,0.631,0.35c0.219,0.09,0.456,0.155,0.703,0.192c0.239,0.036,0.536,0.056,0.882,0.056h0.976c0.41,0,0.814-0.093,1.201-0.273c0.338-0.16,0.676-0.402,1.006-0.725v1.976c0,0.248-0.034,0.463-0.1,0.644c-0.06,0.163-0.219,0.352-0.474,0.557c-0.212,0.176-0.423,0.297-0.628,0.363c-0.21,0.066-0.471,0.103-0.775,0.103h-3.038c-0.404,0-0.743,0.077-1.01,0.231c-0.213,0.122-0.469,0.388-0.469,0.953c0,0.469,0.157,0.797,0.469,0.978c0.267,0.152,0.605,0.229,1.01,0.229h3.204c0.343,0,0.639-0.019,0.879-0.055c0.248-0.038,0.485-0.102,0.707-0.192c0.215-0.091,0.426-0.208,0.629-0.35c0.194-0.138,0.42-0.312,0.672-0.522c0.255-0.213,0.47-0.412,0.637-0.593c0.177-0.194,0.317-0.406,0.418-0.629c0.099-0.223,0.17-0.466,0.207-0.723c0.035-0.249,0.055-0.541,0.055-0.869V20.968C82.153,20.564,82.077,20.226,81.923,19.959z M79.762,26.108c0,0.26-0.085,0.481-0.261,0.677c-0.208,0.235-0.541,0.554-0.985,0.945l-0.004,0.003l-0.003,0.004c-0.19,0.177-0.401,0.328-0.626,0.451c-0.203,0.11-0.447,0.167-0.725,0.167h-0.414c-0.307,0-0.566-0.033-0.777-0.102c-0.204-0.066-0.415-0.188-0.626-0.361c-0.318-0.258-0.434-0.447-0.475-0.56c-0.067-0.18-0.1-0.394-0.1-0.642v-3.039c0-0.247,0.032-0.464,0.1-0.643c0.041-0.112,0.156-0.301,0.474-0.558c0.212-0.175,0.422-0.296,0.627-0.362c0.211-0.068,0.471-0.103,0.777-0.103h0.414c0.292,0,0.534,0.053,0.725,0.157c0.21,0.115,0.424,0.266,0.633,0.447c0.441,0.403,0.776,0.729,0.985,0.967c0.176,0.197,0.261,0.419,0.261,0.678V26.108L79.762,26.108z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M54.386,13.401c-1.261,0-2.288,1.026-2.288,2.288c0,1.263,1.027,2.288,2.288,2.288c1.262,0,2.288-1.025,2.288-2.288C56.674,14.428,55.647,13.401,54.386,13.401z M54.386,16.729c-0.573,0-1.039-0.465-1.039-1.039s0.466-1.039,1.039-1.039s1.041,0.465,1.041,1.039S54.959,16.729,54.386,16.729z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M69.115,27.556l-0.149-4.713c-0.014-0.244-0.029-0.467-0.043-0.675c-0.014-0.225-0.053-0.443-0.112-0.655c-0.062-0.216-0.155-0.424-0.276-0.624c-0.126-0.204-0.295-0.397-0.509-0.579c-0.31-0.267-0.611-0.46-0.892-0.572c-0.285-0.117-0.635-0.175-1.04-0.175h-1.393c-0.357,0-0.69,0.075-0.986,0.224c-0.271,0.136-0.536,0.282-0.789,0.437l-0.005,0.003l-0.002,0.003l-1.153,0.763v-0.055c0-0.403-0.077-0.743-0.231-1.011c-0.179-0.312-0.508-0.468-0.975-0.468c-0.567,0-0.833,0.256-0.957,0.468c-0.151,0.267-0.229,0.605-0.229,1.011v8.407c0,0.403,0.078,0.742,0.229,1.009c0.124,0.214,0.39,0.469,0.957,0.469c0.467,0,0.796-0.158,0.975-0.469c0.154-0.268,0.231-0.607,0.231-1.009V23.78l2.692-1.675c0.055-0.033,0.112-0.064,0.166-0.088c0.044-0.02,0.098-0.034,0.158-0.045c0.07-0.012,0.162-0.019,0.271-0.019h0.5c0.26,0,0.462,0.028,0.598,0.079c0.113,0.042,0.194,0.106,0.248,0.197c0.066,0.107,0.11,0.248,0.134,0.415c0.026,0.192,0.047,0.427,0.061,0.695l0.132,4.269c-0.629,0.408-1.049,1.115-1.049,1.92c0,1.263,1.028,2.288,2.288,2.288c1.263,0,2.287-1.024,2.287-2.288C70.253,28.688,69.794,27.952,69.115,27.556z M67.965,30.568c-0.573,0-1.038-0.465-1.038-1.039c0-0.573,0.465-1.039,1.038-1.039c0.574,0,1.041,0.466,1.041,1.039C69.006,30.104,68.539,30.568,67.965,30.568z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M54.472,19.595h-1.645c-0.403,0-0.742,0.079-1.01,0.23c-0.31,0.181-0.469,0.508-0.469,0.977c0,0.566,0.257,0.832,0.469,0.954c0.266,0.154,0.606,0.231,1.01,0.231h0.749v7.388c0,0.405,0.077,0.744,0.231,1.01c0.178,0.311,0.507,0.469,0.976,0.469c0.566,0,0.832-0.256,0.954-0.469c0.154-0.267,0.232-0.605,0.232-1.01v-8.282c0-0.531-0.115-0.904-0.354-1.145C55.378,19.711,55.004,19.595,54.472,19.595z&quot;/&gt;&#10;    &lt;/g&gt;&#10;    &lt;g&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M39.863,2.691c0-0.153,0.035-0.271,0.106-0.352c0.07-0.083,0.164-0.124,0.282-0.124c0.123,0,0.221,0.037,0.295,0.11c0.073,0.073,0.133,0.142,0.18,0.207l1.594,2.245l1.594-2.245c0.041-0.059,0.1-0.126,0.176-0.203c0.075-0.077,0.176-0.115,0.299-0.115c0.118,0,0.211,0.042,0.282,0.124c0.07,0.082,0.106,0.199,0.106,0.352v5.625c0,0.165-0.028,0.297-0.085,0.396c-0.055,0.1-0.168,0.15-0.338,0.15c-0.165,0-0.275-0.05-0.33-0.15c-0.057-0.1-0.084-0.231-0.084-0.396V3.941l-1.153,1.62c-0.071,0.1-0.142,0.184-0.212,0.251c-0.07,0.067-0.155,0.1-0.255,0.1s-0.184-0.033-0.25-0.1c-0.068-0.068-0.141-0.151-0.217-0.251L40.7,3.941v4.375c0,0.165-0.027,0.297-0.083,0.396c-0.056,0.1-0.166,0.15-0.33,0.15c-0.171,0-0.283-0.05-0.339-0.15c-0.057-0.1-0.084-0.231-0.084-0.396L39.863,2.691L39.863,2.691z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M47.416,8.818c-0.182,0-0.342-0.018-0.479-0.053c-0.139-0.035-0.283-0.111-0.436-0.229c-0.171-0.141-0.282-0.29-0.335-0.445c-0.053-0.156-0.079-0.336-0.079-0.541V7.277c0-0.193,0.026-0.357,0.079-0.493s0.156-0.27,0.309-0.405c0.141-0.124,0.289-0.204,0.444-0.242s0.32-0.057,0.497-0.057h1.734l-0.009-0.264c-0.006-0.146-0.018-0.267-0.035-0.361c-0.018-0.094-0.049-0.166-0.092-0.216c-0.045-0.05-0.105-0.083-0.181-0.102c-0.077-0.017-0.174-0.025-0.291-0.025h-1.382c-0.153,0-0.278-0.028-0.375-0.084s-0.146-0.16-0.146-0.313c0-0.158,0.049-0.265,0.146-0.321c0.097-0.055,0.222-0.083,0.375-0.083h1.373c0.17,0,0.35,0.021,0.536,0.062c0.188,0.042,0.362,0.141,0.521,0.299c0.153,0.153,0.246,0.302,0.281,0.449c0.035,0.147,0.057,0.32,0.062,0.521c0.023,0.639,0.041,1.138,0.053,1.496s0.021,0.625,0.027,0.802c0.005,0.175,0.009,0.287,0.009,0.334c0,0.046,0,0.076,0,0.088c0,0.152-0.029,0.274-0.089,0.365c-0.059,0.091-0.165,0.136-0.316,0.136c-0.146,0-0.248-0.048-0.304-0.145s-0.087-0.222-0.093-0.375l-0.546,0.344c-0.105,0.064-0.196,0.102-0.272,0.114c-0.077,0.012-0.183,0.019-0.317,0.019L47.416,8.818L47.416,8.818L47.416,8.818z M48.111,8.017c0.059,0,0.12-0.012,0.185-0.034c0.065-0.023,0.127-0.054,0.186-0.089l0.713-0.405l-0.017-0.607h-1.753c-0.053,0-0.111,0.004-0.176,0.013c-0.063,0.01-0.123,0.028-0.176,0.058c-0.053,0.029-0.098,0.073-0.132,0.132c-0.036,0.059-0.053,0.137-0.053,0.237v0.273c0,0.1,0.017,0.177,0.053,0.233c0.034,0.056,0.079,0.097,0.132,0.123c0.053,0.026,0.109,0.044,0.172,0.053c0.062,0.008,0.115,0.013,0.163,0.013H48.111L48.111,8.017z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M52.935,8.818c-0.142,0-0.26-0.007-0.356-0.022c-0.097-0.014-0.188-0.04-0.273-0.075c-0.085-0.035-0.167-0.081-0.247-0.136c-0.077-0.056-0.171-0.128-0.276-0.215c-0.105-0.089-0.192-0.168-0.261-0.243c-0.067-0.073-0.119-0.153-0.157-0.238c-0.039-0.085-0.065-0.177-0.08-0.277c-0.015-0.101-0.021-0.217-0.021-0.352V5.869c0-0.135,0.007-0.252,0.021-0.352s0.041-0.193,0.08-0.278c0.038-0.085,0.09-0.164,0.157-0.237c0.068-0.073,0.155-0.154,0.261-0.242c0.104-0.088,0.199-0.159,0.276-0.215c0.08-0.056,0.162-0.101,0.247-0.137c0.086-0.035,0.177-0.061,0.273-0.075c0.097-0.014,0.215-0.021,0.356-0.021h0.413c0.159,0,0.313,0.034,0.463,0.106c0.15,0.069,0.298,0.182,0.444,0.333l0.132,0.141V2.735c0-0.153,0.028-0.277,0.083-0.375c0.057-0.097,0.163-0.145,0.322-0.145c0.152,0,0.257,0.048,0.313,0.145c0.056,0.097,0.084,0.222,0.084,0.375v5.608c0,0.153-0.028,0.278-0.084,0.374c-0.056,0.097-0.16,0.146-0.313,0.146c-0.159,0-0.266-0.049-0.322-0.146c-0.055-0.096-0.083-0.221-0.083-0.374V8.237l-0.185,0.194c-0.118,0.129-0.252,0.226-0.4,0.29c-0.149,0.064-0.302,0.097-0.454,0.097H52.935L52.935,8.818z M53.182,8.017c0.14,0,0.259-0.026,0.356-0.079c0.096-0.053,0.191-0.121,0.286-0.203c0.193-0.176,0.335-0.315,0.427-0.418c0.091-0.103,0.137-0.222,0.137-0.357V6.168c0-0.136-0.046-0.254-0.137-0.357c-0.092-0.102-0.233-0.239-0.427-0.409c-0.089-0.082-0.184-0.151-0.286-0.207c-0.104-0.055-0.223-0.083-0.356-0.083h-0.177c-0.141,0-0.261,0.016-0.36,0.048c-0.1,0.033-0.199,0.089-0.299,0.172c-0.124,0.101-0.202,0.193-0.234,0.282c-0.031,0.088-0.048,0.191-0.048,0.308v1.286c0,0.118,0.017,0.22,0.048,0.309c0.032,0.087,0.11,0.182,0.234,0.281c0.1,0.082,0.199,0.14,0.299,0.172c0.1,0.033,0.22,0.049,0.36,0.049L53.182,8.017L53.182,8.017z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M58.218,8.818c-0.141,0-0.26-0.007-0.356-0.022c-0.097-0.014-0.188-0.04-0.273-0.075c-0.085-0.035-0.167-0.081-0.246-0.136c-0.079-0.056-0.173-0.128-0.278-0.215c-0.104-0.089-0.191-0.168-0.26-0.243c-0.066-0.073-0.12-0.153-0.158-0.238s-0.064-0.177-0.078-0.277c-0.015-0.101-0.022-0.217-0.022-0.352V5.869c0-0.135,0.008-0.252,0.022-0.352c0.014-0.1,0.04-0.193,0.078-0.278s0.092-0.164,0.158-0.237c0.068-0.073,0.155-0.154,0.26-0.242c0.105-0.088,0.199-0.159,0.278-0.215s0.161-0.101,0.246-0.137c0.085-0.035,0.177-0.061,0.273-0.075c0.097-0.014,0.216-0.021,0.356-0.021h0.581c0.141,0,0.26,0.007,0.356,0.021c0.098,0.015,0.188,0.04,0.273,0.075c0.085,0.036,0.167,0.081,0.246,0.137s0.173,0.127,0.277,0.215c0.105,0.089,0.191,0.169,0.26,0.242c0.067,0.074,0.12,0.152,0.158,0.237c0.039,0.085,0.064,0.178,0.08,0.278c0.014,0.1,0.021,0.217,0.021,0.352v0.642c0,0.194-0.04,0.331-0.119,0.41c-0.079,0.08-0.216,0.12-0.409,0.12h-2.598v0.167c0,0.118,0.017,0.221,0.049,0.309c0.032,0.088,0.109,0.182,0.232,0.282c0.101,0.082,0.2,0.139,0.301,0.172c0.1,0.032,0.22,0.048,0.36,0.048h1.355c0.153,0,0.278,0.028,0.375,0.083c0.097,0.056,0.146,0.161,0.146,0.313c0,0.159-0.049,0.266-0.146,0.321c-0.097,0.056-0.222,0.083-0.375,0.083H58.218L58.218,8.818z M57.346,6.238h2.325V5.921c0-0.118-0.017-0.22-0.049-0.308c-0.032-0.089-0.109-0.182-0.233-0.282c-0.1-0.083-0.199-0.139-0.3-0.172c-0.1-0.032-0.22-0.048-0.36-0.048h-0.44c-0.141,0-0.261,0.016-0.36,0.048c-0.1,0.033-0.2,0.089-0.301,0.172c-0.123,0.101-0.2,0.193-0.232,0.282c-0.032,0.088-0.049,0.19-0.049,0.308V6.238L57.346,6.238z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M64.258,6.053c-0.03-0.07-0.047-0.14-0.054-0.21c-0.005-0.071-0.009-0.132-0.009-0.186V4.786c0-0.153,0.028-0.278,0.084-0.375c0.056-0.097,0.159-0.145,0.313-0.145c0.159,0,0.266,0.048,0.321,0.145c0.056,0.097,0.084,0.222,0.084,0.375v0.96l0.765,1.866l0.617-0.863V5.763c0-0.153,0.027-0.278,0.083-0.374c0.057-0.098,0.16-0.146,0.313-0.146c0.158,0,0.265,0.048,0.32,0.146c0.056,0.096,0.084,0.221,0.084,0.374v0.986l0.616,0.863l0.767-1.866v-0.96c0-0.153,0.026-0.278,0.084-0.375c0.055-0.097,0.162-0.145,0.321-0.145c0.151,0,0.256,0.048,0.312,0.145c0.056,0.097,0.083,0.222,0.083,0.375v0.871c0,0.053-0.002,0.115-0.009,0.186c-0.005,0.069-0.022,0.14-0.052,0.21l-0.996,2.439c-0.046,0.111-0.098,0.201-0.153,0.268c-0.056,0.068-0.134,0.102-0.232,0.102c-0.101,0-0.183-0.032-0.248-0.097c-0.064-0.064-0.14-0.155-0.229-0.272l-0.66-0.934l-0.669,0.934c-0.082,0.118-0.157,0.208-0.225,0.272c-0.067,0.065-0.151,0.097-0.252,0.097c-0.094,0-0.17-0.034-0.229-0.102c-0.059-0.067-0.111-0.157-0.158-0.268L64.258,6.053z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M71.331,5.112h-0.422c-0.153,0-0.278-0.028-0.375-0.083c-0.096-0.056-0.146-0.16-0.146-0.313c0-0.158,0.049-0.266,0.146-0.321c0.097-0.056,0.222-0.083,0.375-0.083h0.694c0.194,0,0.33,0.04,0.41,0.119c0.079,0.08,0.118,0.216,0.118,0.41v3.504c0,0.153-0.027,0.278-0.083,0.374c-0.056,0.097-0.16,0.146-0.313,0.146c-0.158,0-0.266-0.049-0.321-0.146c-0.056-0.096-0.084-0.221-0.084-0.374V5.112L71.331,5.112z M71.375,3.395c-0.111,0-0.202-0.026-0.272-0.079c-0.07-0.053-0.105-0.153-0.105-0.299V2.637c0-0.146,0.035-0.246,0.105-0.298c0.07-0.053,0.162-0.08,0.272-0.08h0.379c0.105,0,0.195,0.026,0.269,0.08c0.073,0.052,0.109,0.152,0.109,0.298v0.379c0,0.146-0.036,0.246-0.109,0.299c-0.073,0.052-0.163,0.079-0.269,0.079H71.375z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M75.171,8.818c-0.205,0-0.373-0.026-0.502-0.08c-0.13-0.053-0.229-0.126-0.304-0.22c-0.073-0.094-0.124-0.205-0.154-0.334c-0.03-0.128-0.044-0.27-0.044-0.422v-2.65h-0.388c-0.152,0-0.276-0.028-0.374-0.083c-0.097-0.056-0.145-0.16-0.145-0.313c0-0.158,0.048-0.266,0.145-0.321c0.098-0.056,0.222-0.083,0.374-0.083h0.388V2.735c0-0.153,0.027-0.277,0.084-0.375c0.055-0.097,0.162-0.146,0.321-0.146c0.151,0,0.257,0.049,0.313,0.146c0.056,0.097,0.083,0.222,0.083,0.375V4.31h0.959c0.153,0,0.278,0.028,0.375,0.084c0.097,0.055,0.145,0.163,0.145,0.321c0,0.153-0.048,0.257-0.145,0.312c-0.097,0.056-0.222,0.084-0.375,0.084h-0.959v2.65c0,0.082,0.013,0.146,0.035,0.189c0.023,0.044,0.095,0.066,0.211,0.066h0.713c0.152,0,0.278,0.028,0.375,0.084c0.097,0.055,0.145,0.162,0.145,0.321c0,0.152-0.048,0.257-0.145,0.312c-0.097,0.056-0.223,0.084-0.375,0.084H75.171L75.171,8.818z&quot;/&gt;&#10;     &lt;path fill=&quot;#fdde68&quot; d=&quot;M78.413,8.342c0,0.153-0.027,0.278-0.083,0.375s-0.163,0.146-0.322,0.146c-0.151,0-0.257-0.049-0.312-0.146c-0.057-0.097-0.084-0.222-0.084-0.375V2.734c0-0.152,0.027-0.277,0.084-0.374c0.055-0.097,0.16-0.146,0.312-0.146c0.159,0,0.267,0.049,0.322,0.146c0.056,0.097,0.083,0.222,0.083,0.374v2.271l0.651-0.432c0.106-0.064,0.215-0.125,0.326-0.18c0.111-0.056,0.235-0.083,0.37-0.083h0.59c0.158,0,0.292,0.021,0.4,0.066c0.108,0.043,0.225,0.119,0.348,0.225c0.083,0.069,0.146,0.144,0.193,0.22s0.082,0.156,0.105,0.238c0.023,0.083,0.038,0.167,0.045,0.255c0.005,0.087,0.011,0.182,0.017,0.281c0.019,0.446,0.031,0.823,0.04,1.132c0.01,0.309,0.016,0.563,0.021,0.765c0.007,0.203,0.012,0.361,0.014,0.476c0.003,0.115,0.006,0.199,0.01,0.255c0.003,0.056,0.004,0.092,0.004,0.106c0,0.015,0,0.025,0,0.031c0,0.153-0.029,0.274-0.089,0.366c-0.059,0.091-0.163,0.136-0.316,0.136c-0.146,0-0.248-0.047-0.304-0.141c-0.057-0.094-0.087-0.214-0.093-0.361l-0.078-2.562c-0.007-0.118-0.016-0.218-0.027-0.304c-0.012-0.085-0.034-0.156-0.07-0.215c-0.034-0.059-0.088-0.101-0.158-0.127s-0.167-0.04-0.291-0.04c-0.088,0-0.158,0-0.211,0s-0.097,0.002-0.132,0.009c-0.035,0.005-0.065,0.015-0.092,0.026c-0.027,0.012-0.056,0.027-0.084,0.044l-1.189,0.739V8.342L78.413,8.342z&quot;/&gt;&#10;    &lt;/g&gt;&#10;   &lt;/g&gt;&#10;  &lt;/g&gt;&#10; &lt;/g&gt;&#10;&lt;/svg&gt;&#10;"/>
+            <property name="lastfilename" value="/usr/share/fritzing/parts/svg/core/pcb/new Made with Fritzing.svg"/>
+            <property name="originalWidth" value="29.986224"/>
+            <property name="originalHeight" value="13.4055612"/>
+            <title>IMG3</title>
+            <views>
+                <pcbView layer="copper1">
+                    <geometry z="8.50075" x="40.1524" y="39.9401"/>
+                </pcbView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032437" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7518</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.5" x="144" y="-135" x1="0" y1="0" x2="-54" y2="0" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50001" x="144" y="-135" x1="0" y1="0" x2="-54" y2="0" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031886" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009422" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.5" x="144" y="-135" x1="0" y1="0" x2="-54" y2="0" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032441" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7520</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50001" x="144" y="-108" x1="0" y1="0" x2="-54" y2="-9" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032445" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.5" x="144" y="-108" x1="0" y1="0" x2="-54" y2="-9" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031886" layer="copper1"/>
+                                <connect connectorId="connector0" modelIndex="86032445" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009422" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50002" x="144" y="-108" x1="0" y1="0" x2="-9.15199" y2="-8.97658" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032445" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032445" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7522</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50002" x="134.848" y="-116.977" x1="0" y1="0" x2="-44.848" y2="-0.0234164" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032441" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50011" x="134.848" y="-116.977" x1="0" y1="0" x2="-44.848" y2="-0.0234164" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031886" layer="copper0"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032441" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50001" x="134.848" y="-116.977" x1="0" y1="0" x2="-44.848" y2="-0.0234164" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032441" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032452" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7524</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50003" x="-9.09818" y="-63.0374" x1="0" y1="0" x2="99.0982" y2="-8.96262" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032458" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032453" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.5001" x="-9.09818" y="-63.0374" x1="0" y1="0" x2="99.0982" y2="-8.96262" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031886" layer="copper1"/>
+                                <connect connectorId="connector0" modelIndex="86032458" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032453" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50004" x="-13.5893" y="-76.415" x1="0" y1="0" x2="99.0637" y2="0" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032458" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032453" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032453" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7525</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50004" x="-18" y="-71.98" x1="0" y1="0" x2="8.90182" y2="8.94262" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032452" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50009" x="-18" y="-71.98" x1="0" y1="0" x2="8.90182" y2="8.94262" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032452" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50005" x="-18" y="-71.98" x1="0" y1="0" x2="4.41074" y2="-4.43497" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032452" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032458" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7527</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50005" x="80.9088" y="-63.0374" x1="0" y1="0" x2="9.0912" y2="-8.96262" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032452" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50008" x="80.9088" y="-63.0374" x1="0" y1="0" x2="9.0912" y2="-8.96262" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031886" layer="copper0"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032452" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50003" x="85.4745" y="-76.415" x1="0" y1="0" x2="4.52552" y2="4.41497" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032452" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032465" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7529</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50006" x="53.9392" y="-53.9392" x1="0" y1="0" x2="-17.9917" y2="-18.0608" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032471" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50007" x="53.9392" y="-53.9392" x1="0" y1="0" x2="-17.9917" y2="-18.0608" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031860" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032471" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50006" x="40.5708" y="-67.5524" x1="0" y1="0" x2="-4.62334" y2="-4.44759" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032471" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032466" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7530</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50007" x="144" y="-81" x1="0" y1="0" x2="-90.0608" y2="27.0608" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032471" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50006" x="144" y="-81" x1="0" y1="0" x2="-90.0608" y2="27.0608" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032471" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009422" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50008" x="144" y="-81" x1="0" y1="0" x2="-13.4249" y2="13.4476" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032471" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032471" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7532</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50008" x="126.075" y="-63.0374" x1="0" y1="0" x2="-72.1356" y2="9.09818" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032465" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032466" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50005" x="126.075" y="-63.0374" x1="0" y1="0" x2="-72.1356" y2="9.09818" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032465" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032466" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50007" x="130.575" y="-67.5524" x1="0" y1="0" x2="-90.0042" y2="0" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032465" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032466" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032478" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7534</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50009" x="53.9392" y="-80.9088" x1="0" y1="0" x2="90.0608" y2="8.9088" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032608" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032479" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50004" x="53.9392" y="-80.9088" x1="0" y1="0" x2="90.0608" y2="8.9088" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009422" layer="copper1"/>
+                                <connect connectorId="connector0" modelIndex="86032608" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032479" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50012" x="36.0411" y="-80.9447" x1="0" y1="0" x2="17.8483" y2="-0.0158925" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032608" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032479" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032479" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7535</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.5001" x="35.9475" y="-81" x1="0" y1="0" x2="17.9917" y2="0.0911964" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032478" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50003" x="35.9475" y="-81" x1="0" y1="0" x2="17.9917" y2="0.0911964" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032478" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031860" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50013" x="35.9475" y="-81" x1="0" y1="0" x2="0.093582" y2="0.0552749" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032478" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032484" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7537</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50011" x="90.007" y="-53.9392" x1="0" y1="0" x2="53.993" y2="-18.0608" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032489" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032608" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50002" x="90.007" y="-53.9392" x1="0" y1="0" x2="53.993" y2="-18.0608" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032489" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032608" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50011" x="72.1056" y="-62.9975" x1="0" y1="0" x2="62.8023" y2="-0.0251764" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032489" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032608" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032489" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7539</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50012" x="126.075" y="-53.9392" x1="0" y1="0" x2="17.9252" y2="-18.0608" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032484" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50021" x="126.075" y="-53.9392" x1="0" y1="0" x2="17.9252" y2="-18.0608" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009422" layer="copper0"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032484" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.5001" x="134.908" y="-63.0227" x1="0" y1="0" x2="9.09212" y2="-8.97734" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector7" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032484" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032494" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7541</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50013" x="35.9475" y="-90" x1="0" y1="0" x2="-53.9475" y2="0.02" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.5002" x="35.9475" y="-90" x1="0" y1="0" x2="-53.9475" y2="0.02" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031860" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50014" x="35.9475" y="-90" x1="0" y1="0" x2="-53.9475" y2="0.02" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032498" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7543</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50014" x="35.9475" y="-99" x1="0" y1="0" x2="-53.9475" y2="0.02" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50019" x="35.9475" y="-99" x1="0" y1="0" x2="-53.9475" y2="0.02" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031860" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50015" x="35.9475" y="-99" x1="0" y1="0" x2="-53.9475" y2="0.02" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032504" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7545</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50015" x="-13.5893" y="-85.4745" x1="0" y1="0" x2="-4.41074" y2="4.49448" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032510" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50018" x="-13.5893" y="-85.4745" x1="0" y1="0" x2="-4.41074" y2="4.49448" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032510" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50016" x="-13.5893" y="-85.4745" x1="0" y1="0" x2="-4.41074" y2="4.49448" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032510" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032505" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7546</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50016" x="90" y="-126" x1="0" y1="0" x2="-103.589" y2="40.5255" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032510" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50017" x="90" y="-126" x1="0" y1="0" x2="-103.589" y2="40.5255" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032510" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031886" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50018" x="90" y="-126" x1="0" y1="0" x2="-40.5666" y2="40.5255" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032510" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032510" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7548</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50017" x="44.9036" y="-85.4745" x1="0" y1="0" x2="-58.4929" y2="0" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032504" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032505" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50016" x="44.9036" y="-85.4745" x1="0" y1="0" x2="-58.4929" y2="0" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032504" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032505" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50017" x="49.4334" y="-85.4745" x1="0" y1="0" x2="-63.0227" y2="0" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032504" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032505" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032517" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7550</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50018" x="-13.5893" y="-103.593" x1="0" y1="0" x2="-4.41074" y2="-4.38651" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032523" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50015" x="-13.5893" y="-103.593" x1="0" y1="0" x2="-4.41074" y2="-4.38651" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032523" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50019" x="-13.5893" y="-103.593" x1="0" y1="0" x2="-4.41074" y2="-4.38651" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032523" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032518" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7551</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50019" x="90" y="-81" x1="0" y1="0" x2="-103.589" y2="-22.5935" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032528" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50014" x="90" y="-81" x1="0" y1="0" x2="-103.589" y2="-22.5935" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032528" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031886" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50022" x="90" y="-81" x1="0" y1="0" x2="-17.8944" y2="0.0393824" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032528" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector6" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032523" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7553</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.5002" x="44.9036" y="-103.593" x1="0" y1="0" x2="-58.4929" y2="0" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032517" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032528" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50013" x="44.9036" y="-103.593" x1="0" y1="0" x2="-58.4929" y2="0" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032517" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032528" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50021" x="49.5884" y="-103.478" x1="0" y1="0" x2="-63.1776" y2="-0.115703" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032517" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032528" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032528" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7555</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50021" x="67.5524" y="-80.9447" x1="0" y1="0" x2="-22.6488" y2="-22.6488" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032523" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032518" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50012" x="67.5524" y="-80.9447" x1="0" y1="0" x2="-22.6488" y2="-22.6488" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032523" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032518" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.5002" x="72.1056" y="-80.9606" x1="0" y1="0" x2="-22.5172" y2="-22.5172" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032523" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032518" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032535" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7557</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50022" x="-13.5893" y="-112.456" x1="0" y1="0" x2="103.589" y2="4.45605" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032541" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032536" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50031" x="-13.5893" y="-112.456" x1="0" y1="0" x2="103.589" y2="4.45605" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031886" layer="copper1"/>
+                                <connect connectorId="connector0" modelIndex="86032541" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032536" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50024" x="-13.5893" y="-112.456" x1="0" y1="0" x2="99.0637" y2="0" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032541" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032536" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032536" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7558</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50023" x="-18" y="-116.98" x1="0" y1="0" x2="4.41074" y2="4.52395" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032535" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.5003" x="-18" y="-116.98" x1="0" y1="0" x2="4.41074" y2="4.52395" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032535" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50025" x="-18" y="-116.98" x1="0" y1="0" x2="4.41074" y2="4.52395" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032535" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032541" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7560</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50024" x="85.4745" y="-112.456" x1="0" y1="0" x2="4.52552" y2="4.45605" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032535" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50029" x="85.4745" y="-112.456" x1="0" y1="0" x2="4.52552" y2="4.45605" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031886" layer="copper0"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032535" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50023" x="85.4745" y="-112.456" x1="0" y1="0" x2="4.52552" y2="4.45605" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032535" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032548" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7562</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50025" x="139.438" y="-103.593" x1="0" y1="0" x2="-103.49" y2="-4.40651" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032559" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032549" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50028" x="139.438" y="-103.593" x1="0" y1="0" x2="-103.49" y2="-4.40651" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031860" layer="copper1"/>
+                                <connect connectorId="connector0" modelIndex="86032559" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032549" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50028" x="139.438" y="-103.593" x1="0" y1="0" x2="-80.9942" y2="0.115703" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032559" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032549" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032549" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7563</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50026" x="144" y="-99" x1="0" y1="0" x2="-4.56237" y2="-4.59349" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032548" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50027" x="144" y="-99" x1="0" y1="0" x2="-4.56237" y2="-4.59349" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032548" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009422" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50029" x="144" y="-99" x1="0" y1="0" x2="-4.56237" y2="-4.59349" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032548" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032554" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7565</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50027" x="49.4334" y="-107.926" x1="0" y1="0" x2="-13.4859" y2="-0.0736998" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032559" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50026" x="49.4334" y="-107.926" x1="0" y1="0" x2="-13.4859" y2="-0.0736998" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031860" layer="copper0"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032559" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50027" x="53.8894" y="-108.032" x1="0" y1="0" x2="-17.9419" y2="0.0318241" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector3" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032559" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032559" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7567</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50028" x="53.9632" y="-103.593" x1="0" y1="0" x2="-4.52975" y2="-4.33281" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032554" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032548" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50025" x="53.9632" y="-103.593" x1="0" y1="0" x2="-4.52975" y2="-4.33281" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032554" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032548" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50026" x="58.4434" y="-103.478" x1="0" y1="0" x2="-4.55403" y2="-4.55403" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032554" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032548" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032566" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7569</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50029" x="40.5708" y="-121.516" x1="0" y1="0" x2="-4.62334" y2="4.51556" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031860" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032603" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50024" x="40.5708" y="-121.516" x1="0" y1="0" x2="-4.62334" y2="4.51556" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031860" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032603" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.5003" x="85.4745" y="-116.986" x1="0" y1="0" x2="-49.527" y2="-0.0141929" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector2" modelIndex="86031860" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032603" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032567" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7570</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.5003" x="144" y="-90" x1="0" y1="0" x2="-103.429" y2="-31.5156" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032572" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009422" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50023" x="144" y="-90" x1="0" y1="0" x2="-103.429" y2="-31.5156" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032572" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009422" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50033" x="144" y="-90" x1="0" y1="0" x2="-31.5439" y2="-31.5156" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032572" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86009422" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032572" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7572</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50031" x="112.456" y="-121.516" x1="0" y1="0" x2="-71.8852" y2="0" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032603" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032567" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50022" x="112.456" y="-121.516" x1="0" y1="0" x2="-71.8852" y2="0" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032603" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032567" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50032" x="112.456" y="-121.516" x1="0" y1="0" x2="-22.4518" y2="-1.42109e-14" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032603" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032567" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032579" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7574</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50032" x="58.4929" y="-130.575" x1="0" y1="0" x2="31.5071" y2="31.5751" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032585" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50039" x="58.4929" y="-130.575" x1="0" y1="0" x2="31.5071" y2="31.5751" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031886" layer="copper1"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032585" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50034" x="58.4929" y="-130.575" x1="0" y1="0" x2="31.5071" y2="31.5751" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector4" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032585" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032580" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7575</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50033" x="-18" y="-134.98" x1="0" y1="0" x2="76.4929" y2="4.40493" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032585" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50038" x="-18" y="-134.98" x1="0" y1="0" x2="76.4929" y2="4.40493" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032585" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50036" x="-18" y="-134.98" x1="0" y1="0" x2="4.41074" y2="4.40493" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032585" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032585" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7577</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50034" x="-13.5893" y="-130.575" x1="0" y1="0" x2="72.0822" y2="0" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032579" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032580" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50037" x="-13.5893" y="-130.575" x1="0" y1="0" x2="72.0822" y2="0" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032579" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032580" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50035" x="-13.5893" y="-130.575" x1="0" y1="0" x2="72.0822" y2="0" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032579" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032580" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032592" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7579</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50035" x="-13.5893" y="-121.516" x1="0" y1="0" x2="103.589" y2="31.5156" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032598" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032593" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50036" x="-13.5893" y="-121.516" x1="0" y1="0" x2="103.589" y2="31.5156" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031886" layer="copper1"/>
+                                <connect connectorId="connector0" modelIndex="86032598" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032593" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50038" x="-13.5893" y="-121.516" x1="0" y1="0" x2="72.0822" y2="0" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032598" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032593" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032593" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7580</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50036" x="-18" y="-125.98" x1="0" y1="0" x2="4.41074" y2="4.46444" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032592" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009413" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50035" x="-18" y="-125.98" x1="0" y1="0" x2="4.41074" y2="4.46444" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032592" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009413" layer="copper1"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50039" x="-18" y="-125.98" x1="0" y1="0" x2="4.41074" y2="4.46444" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032592" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86009413" layer="schematic"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032598" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7582</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50037" x="9.05951" y="-121.516" x1="0" y1="0" x2="80.9405" y2="31.5156" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031886" layer="breadboard"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032592" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50034" x="9.05951" y="-121.516" x1="0" y1="0" x2="80.9405" y2="31.5156" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031886" layer="copper0"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032592" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50037" x="58.4929" y="-121.516" x1="0" y1="0" x2="31.5071" y2="31.5156" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector5" modelIndex="86031886" layer="schematic"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032592" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032603" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7584</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50038" x="90.0042" y="-121.516" x1="0" y1="0" x2="-4.52975" y2="4.52975" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032566" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032572" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50033" x="90.0042" y="-121.516" x1="0" y1="0" x2="-4.52975" y2="4.52975" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032566" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032572" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50031" x="90.0042" y="-121.516" x1="0" y1="0" x2="-4.52975" y2="4.52975" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032566" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032572" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+        <instance moduleIdRef="WireModuleID" modelIndex="86032608" path=":/resources/parts/core/wire.fzp">
+            <title>Wire7586</title>
+            <views>
+                <breadboardView layer="breadboardWire">
+                    <geometry z="3.50039" x="53.8894" y="-80.9606" x1="0" y1="0" x2="0.073739" y2="17.938" wireFlags="128"/>
+                    <wireExtras mils="22.2222" color="#418dd9" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032484" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="breadboardWire">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032478" layer="breadboardWire"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </breadboardView>
+                <pcbView layer="copper1trace">
+                    <geometry z="9.50032" x="53.8894" y="-80.9606" x1="0" y1="0" x2="0.073739" y2="17.938" wireFlags="128"/>
+                    <wireExtras mils="11.1111" color="#f2c600" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032484" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="copper1trace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032478" layer="copper1trace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </pcbView>
+                <schematicView layer="schematicTrace">
+                    <geometry z="5.50009" x="53.8894" y="-80.9606" x1="0" y1="0" x2="18.2161" y2="17.9631" wireFlags="128"/>
+                    <wireExtras mils="9.7222" color="#404040" opacity="1" banded="0"/>
+                    <connectors>
+                        <connector connectorId="connector1" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector0" modelIndex="86032484" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                        <connector connectorId="connector0" layer="schematicTrace">
+                            <geometry x="0" y="0"/>
+                            <connects>
+                                <connect connectorId="connector1" modelIndex="86032478" layer="schematicTrace"/>
+                            </connects>
+                        </connector>
+                    </connectors>
+                </schematicView>
+            </views>
+        </instance>
+    </instances>
+</module>


### PR DESCRIPTION
This adapter lets you use shields designed for the D1 Mini board.